### PR TITLE
Hardening: verwijder onnodige web_accessible_resources, encode hex in externe URL's

### DIFF
--- a/background.js
+++ b/background.js
@@ -211,7 +211,7 @@ chrome.notifications.onButtonClicked.addListener(async (notifId, btnIdx) => {
   if (btnIdx === 0) {
     const hexParts = notifId.split('_');
     const hex = hexParts.length >= 3 ? hexParts[1] : '';
-    chrome.tabs.create({ url: `https://globe.airplanes.live${hex ? `/?icao=${hex}` : ''}` });
+    chrome.tabs.create({ url: `https://globe.airplanes.live${hex ? `/?icao=${encodeURIComponent(hex)}` : ''}` });
   }
   if (btnIdx === 1) {
     const parts = notifId.split('_');

--- a/manifest.json
+++ b/manifest.json
@@ -29,16 +29,5 @@
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
-  },
-  "web_accessible_resources": [
-    {
-      "resources": [
-        "offscreen.html",
-        "offscreen.js"
-      ],
-      "matches": [
-        "chrome-extension://*/*"
-      ]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
- web_accessible_resources verwijderd uit manifest.json, offscreen-document werkt hier niet minder goed van, het was al nooit nodig
- encodeURIComponent() toegevoegd rond hex/icao in de drie plekken die een globe.airplanes.live URL bouwen (background.js, live.js, history.js)
- Geen functionele wijzigingen voor de gebruiker